### PR TITLE
マークダウンパーサーの改行処理を改善

### DIFF
--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -25,7 +25,7 @@ export async function getStaticPaths() {
 
 type Props = Organization;
 const org = Astro.props;
-const description = marked.parse(org.attributes.description);
+const description = marked.parse(org.attributes.description, { breaks: true });
 
 const contactInfo = enumerateContactInfomations(org);
 


### PR DESCRIPTION
Resolves #16 
各団体ページにおける改行処理において、単一の改行も改行としてみなされるように修正した
Before:
![image](https://github.com/user-attachments/assets/65425dca-7376-47b7-a0f6-fdc54e995a0a)
After:
![image](https://github.com/user-attachments/assets/c203ed63-8b07-4b36-a576-9c22ca8f665c)