### PR TITLE
ヘッダーメニューの整理

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,16 +14,6 @@ const Links: HeaderLink[] = [
     text: "新歓祭について",
     icon: "ri:question-line",
   },
-  {
-    href: "/timetable",
-    text: "タイムテーブル",
-    icon: "ri:calendar-todo-line",
-  },
-  {
-    href: "/privacy",
-    text: "プライバシーポリシー",
-    icon: "ri:shield-line",
-  },
   // {
   //   href: "/faq",
   //   text: "よくある質問",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,7 +55,7 @@ const committeeEmail = "shinkan@stb.tsukuba.ac.jp";
     <section>
       <h2>新歓祭当日のステージタイムテーブル</h2>
       <div class="button-wrapper">
-        <a href="https://shinkan-web.zdk.tsukuba.ac.jp/timetable/" class="button">タイムテーブル (新歓祭当日)</a>
+        <a href="/timetable" class="button">タイムテーブル (新歓祭当日)</a>
       </div>
     </section>
     <section>
@@ -174,7 +174,7 @@ const committeeEmail = "shinkan@stb.tsukuba.ac.jp";
       <section>
         <h2>プライバシーポリシー</h2>
         <section>
-          <h2>Sentryによる情報収集について</h2>
+          <h3>Sentryによる情報収集について</h3>
           <p>
             当サイトでは、品質向上と安定稼働のため、Functional
             Software社のサービスであるSentryを利用しています。これにより、サイト利用中にエラーが発生した場合や通常利用セッションの一部において、個人を特定しない範囲で必要最小限の情報
@@ -191,7 +191,7 @@ const committeeEmail = "shinkan@stb.tsukuba.ac.jp";
           </ul>
         </section>
         <section>
-          <h2>Google Analyticsによる情報収集について</h2>
+          <h3>Google Analyticsによる情報収集について</h3>
           <p>
             当サイトでは、利用者のアクセス状況の把握のため、Google社のサービスであるGoogle Analyticsを利用しています。
             これらのGoogle

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -53,6 +53,12 @@ const committeeEmail = "shinkan@stb.tsukuba.ac.jp";
       <a href={googleCalendarUrl} target="_blank">Google Calendarに追加する</a>
     </section>
     <section>
+      <h2>新歓祭当日のステージタイムテーブル</h2>
+      <div class="button-wrapper">
+        <a href="https://shinkan-web.zdk.tsukuba.ac.jp/timetable/" class="button">タイムテーブル (新歓祭当日)</a>
+      </div>
+    </section>
+    <section>
       <h2>場所</h2>
       <p>第一エリア、第二エリア、第三エリア、石の広場及びその周辺</p>
       <div>
@@ -164,6 +170,59 @@ const committeeEmail = "shinkan@stb.tsukuba.ac.jp";
             <li><a href="https://210o.net/" target="_blank" rel="noopener">江波戸憧音</a> (OGP画像・その他広報系デザイン)</li>
             <li><a href="https://github.com/N1su1" target="_blank" rel="noopener">にすい</a> (広報系デザイン)</li>
         </ul>
+      </section>
+      <section>
+        <h2>プライバシーポリシー</h2>
+        <section>
+          <h2>Sentryによる情報収集について</h2>
+          <p>
+            当サイトでは、品質向上と安定稼働のため、Functional
+            Software社のサービスであるSentryを利用しています。これにより、サイト利用中にエラーが発生した場合や通常利用セッションの一部において、個人を特定しない範囲で必要最小限の情報
+            （例: 本サイト上における行動ログや、その他各種エラー・ログなど）がFunctional
+            Software社のサーバーに送信されます。収集された情報はFunctional
+            Software社のプライバシーポリシーに基づき管理されます。利用者はこのサイトを利用することで、Functional
+            Software社並びにサイト管理者によるデータの処理について、許可を与えたとみなします。
+          </p>
+          <p>Sentryのプライバシーポリシーに関しては以下のサイトをご参照ください。</p>
+          <ul>
+            <li>
+              <a href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer">Sentry プライバシーポリシー</a>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h2>Google Analyticsによる情報収集について</h2>
+          <p>
+            当サイトでは、利用者のアクセス状況の把握のため、Google社のサービスであるGoogle Analyticsを利用しています。
+            これらのGoogle
+            Analyticsを通して収集されたデータは、Google社の利用規約・プライバシーポリシーに基づいて管理されており、利用者はこのサイトを利用することで、Google社、並びにサイト管理者によるデータの処理について、許可を与えたとみなします。
+            なお、こうしたデータは匿名で収集されており、個人を特定するものではありません。
+          </p>
+          <p>Google Analyticsの利用規約及びプライバシーポリシーに関しては以下のサイトをご参照ください。</p>
+          <ul>
+            <li>
+              <a href="https://www.google.com/analytics/terms/jp.html" target="_blank" rel="noopener noreferrer"
+                >Google Analytics 利用規約</a
+              >
+            </li>
+            <li>
+              <a href="https://policies.google.com/privacy?hl=ja" target="_blank" rel="noopener noreferrer"
+                >Googleプライバシーポリシー</a
+              >
+            </li>
+          </ul>
+          <p>
+            また、こうしたGoogle Analyticsによる情報収集に関しましては、Google アナリティクス オプトアウト
+            アドオンを導入することで拒否することが可能とされています。適時ご活用ください。
+          </p>
+          <ul>
+            <li>
+              <a href="https://support.google.com/analytics/answer/181881?hl=ja" target="_blank" rel="noopener noreferrer"
+                >Google アナリティクス オプトアウト アドオン</a
+              >
+            </li>
+          </ul>
+        </section>
       </section>
       <section class="contacts">
         <h2>各種お問い合わせについて</h2>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -8,54 +8,7 @@ import Layout from "../layouts/Layout.astro";
       <h1>プライバシーポリシー</h1>
     </hgroup>
     <section>
-      <h2>Sentryによる情報収集について</h2>
-      <p>
-        当サイトでは、品質向上と安定稼働のため、Functional
-        Software社のサービスであるSentryを利用しています。これにより、サイト利用中にエラーが発生した場合や通常利用セッションの一部において、個人を特定しない範囲で必要最小限の情報
-        （例: 本サイト上における行動ログや、その他各種エラー・ログなど）がFunctional
-        Software社のサーバーに送信されます。収集された情報はFunctional
-        Software社のプライバシーポリシーに基づき管理されます。利用者はこのサイトを利用することで、Functional
-        Software社並びにサイト管理者によるデータの処理について、許可を与えたとみなします。
-      </p>
-      <p>Sentryのプライバシーポリシーに関しては以下のサイトをご参照ください。</p>
-      <ul>
-        <li>
-          <a href="https://sentry.io/privacy/" target="_blank" rel="noopener noreferrer">Sentry プライバシーポリシー</a>
-        </li>
-      </ul>
-    </section>
-    <section>
-      <h2>Google Analyticsによる情報収集について</h2>
-      <p>
-        当サイトでは、利用者のアクセス状況の把握のため、Google社のサービスであるGoogle Analyticsを利用しています。
-        これらのGoogle
-        Analyticsを通して収集されたデータは、Google社の利用規約・プライバシーポリシーに基づいて管理されており、利用者はこのサイトを利用することで、Google社、並びにサイト管理者によるデータの処理について、許可を与えたとみなします。
-        なお、こうしたデータは匿名で収集されており、個人を特定するものではありません。
-      </p>
-      <p>Google Analyticsの利用規約及びプライバシーポリシーに関しては以下のサイトをご参照ください。</p>
-      <ul>
-        <li>
-          <a href="https://www.google.com/analytics/terms/jp.html" target="_blank" rel="noopener noreferrer"
-            >Google Analytics 利用規約</a
-          >
-        </li>
-        <li>
-          <a href="https://policies.google.com/privacy?hl=ja" target="_blank" rel="noopener noreferrer"
-            >Googleプライバシーポリシー</a
-          >
-        </li>
-      </ul>
-      <p>
-        また、こうしたGoogle Analyticsによる情報収集に関しましては、Google アナリティクス オプトアウト
-        アドオンを導入することで拒否することが可能とされています。適時ご活用ください。
-      </p>
-      <ul>
-        <li>
-          <a href="https://support.google.com/analytics/answer/181881?hl=ja" target="_blank" rel="noopener noreferrer"
-            >Google アナリティクス オプトアウト アドオン</a
-          >
-        </li>
-      </ul>
+      <p><a href="/about">新歓祭・新歓Webについて</a>ページに移動しました</p>
     </section>
   </article>
 </Layout>


### PR DESCRIPTION
タイムテーブルへのリンク・プライバシーポリシーを/aboutに移動し、ヘッダーからプライバシーポリシーとタイムテーブルを削除した